### PR TITLE
Reformat source code to match style guide

### DIFF
--- a/src/Example.purs
+++ b/src/Example.purs
@@ -12,24 +12,24 @@ import Skald
 
 main :: Application
 main = tale "Example Tale"
-    # by "Ian D. Bollinger"
-    # thatBeginsIn cavernEntrance
-    # withPlaces [
-        cavernInterior,
-        cavernSpring,
-        well,
-        northernInnerWardCourtyard,
-        keepApproach,
-        southernInnerWardCourtyard,
-        library,
-        gallery,
-        greatHall,
-        kitchen,
-        larder,
-        gatehouse,
-        outerWardCourtyard
+  # by "Ian D. Bollinger"
+  # thatBeginsIn cavernEntrance
+  # withPlaces
+    [ cavernInterior
+    , cavernSpring
+    , well
+    , northernInnerWardCourtyard
+    , keepApproach
+    , southernInnerWardCourtyard
+    , library
+    , gallery
+    , greatHall
+    , kitchen
+    , larder
+    , gatehouse
+    , outerWardCourtyard
     ]
-    # run
+  # run
 
 -- Volume - Body matter --------------------------------------------------------
 
@@ -45,72 +45,72 @@ cavernEntrance = place "cavern entrance"
 
 cavernEntranceDescription :: String
 cavernEntranceDescription = "The mouth of the cave was little more than a slit\
-    \ between two boulders; it lay to the north."
+  \ between two boulders; it lay to the north."
 
 boulders :: Object
 boulders = scenery "boulders"
-    "Though close, you could squeeze easily between the rocks."
+  "Though close, you could squeeze easily between the rocks."
 
 -- Section - The cavern interior -----------------------------------------------
 
 cavernInterior :: Place
 cavernInterior = place "cavern interior"
-    # withExits [south `to` "cavern entrance", north `to` "cavern spring"]
-    # withDescription "A sliver of light filtered through the southern\
-    \ entrance, illuminating a thin streak across the cavern floor. The blue\
-    \ glow of your alchemic lantern revealed a tunnel leading north."
+  # withExits [south `to` "cavern entrance", north `to` "cavern spring"]
+  # withDescription "A sliver of light filtered through the southern entrance,\
+  \ illuminating a thin streak across the cavern floor. The blue glow of your\
+  \ alchemic lantern revealed a tunnel leading north."
 
 -- Section - The cavern spring -------------------------------------------------
 
 cavernSpring :: Place
 cavernSpring = place "cavern spring"
-    # withExits [south `to` "cavern interior", west `to` "well"]
-    # withDescription cavernSpringDescription
-    # containing [stalactites, poolOfWater, waterline, aperture]
+  # withExits [south `to` "cavern interior", west `to` "well"]
+  # withDescription cavernSpringDescription
+  # containing [stalactites, poolOfWater, waterline, aperture]
 
 cavernSpringDescription :: String
 cavernSpringDescription = "Stalactites glistened over a pool of water. Not far\
-    \ below them, a waterline marked the cave walls above your head. There\
-    \ was an aperture in the wall to the west. A tunnel lead to the south."
+  \ below them, a waterline marked the cave walls above your head. There was an\
+  \ aperture in the wall to the west. A tunnel lead to the south."
 
 stalactites :: Object
 stalactites = scenery "stalactites"
-    "Bone-white protuberances hung from the cave’s ceiling."
+  "Bone-white protuberances hung from the cave’s ceiling."
 
 poolOfWater :: Object
 poolOfWater = scenery "pool of water"
-    "You suspected a spring fed this pool."
-    # insteadOf taking (say "You lacked a container to carry water.")
+  "You suspected a spring fed this pool."
+  # insteadOf taking (say "You lacked a container to carry water.")
 
 waterline :: Object
 waterline = scenery "waterline"
-    "The water had been much higher in the past."
+  "The water had been much higher in the past."
 
 aperture :: Object
 aperture = scenery "aperture"
-    "You could not make out what was on the other side."
+  "You could not make out what was on the other side."
 
 -- Section - The well ----------------------------------------------------------
 
 well :: Place
 well = place "well"
-    # withExits [
-        east `to` "cavern spring",
-        up `to` "northern inner ward courtyard"
-        ]
-    # withDescription "You found yourself at the bottom of a dry well. A spiral\
-        \ staircase wound around the well’s interior. A hole in the east side\
-        \ of the well lead to the spring that once supplied it."
-    # containing [spiralStaircase, hole]
+  # withExits
+    [ east `to` "cavern spring"
+    , up `to` "northern inner ward courtyard"
+    ]
+  # withDescription "You found yourself at the bottom of a dry well. A spiral\
+    \ staircase wound around the well’s interior. A hole in the east side of\
+    \ the well lead to the spring that once supplied it."
+  # containing [spiralStaircase, hole]
 
 spiralStaircase :: Object
 spiralStaircase = scenery "spiral staircase"
-    "Running along the stairs was a low wall, above which sat a series of\
-    \ arches that held up the span of stairs overhead."
+  "Running along the stairs was a low wall, above which sat a series of arches\
+  \ that held up the span of stairs overhead."
 
 hole :: Object
 hole = scenery "hole"
-    "You could not make out what was on the other side."
+  "You could not make out what was on the other side."
 
 -- Chapter - Inside the walls of Akkonai ---------------------------------------
 
@@ -118,241 +118,238 @@ hole = scenery "hole"
 
 northernInnerWardCourtyard :: Place
 northernInnerWardCourtyard = place "northern inner ward courtyard"
-    # withExits [
-        down `to` "well",
-        north `to` "keep approach",
-        south `to` "southern inner ward courtyard"
-        ]
-    # whenDescribing (\x ->
-        "Stairs spiraled around a seemingly bottomless hole in "
-        <> (if unvisited x then "what must be " else "")
-        <> "the inner ward of Akkonai."
-        <> (if unvisited x then " You exhaled—both relieved and fatigued."
-            else "")
-        <> " A tirùnga grew from the center of the ward, its roots hidden\
-            \ beneath a blanket of fog. Stairs ran north to the keep."
-        )
-    # containing [fog, tirungaTree, roots, leaves]
+  # withExits
+    [ down `to` "well"
+    , north `to` "keep approach"
+    , south `to` "southern inner ward courtyard"
+    ]
+  # whenDescribing (\x ->
+    "Stairs spiraled around a seemingly bottomless hole in "
+    <> (if unvisited x then "what must be " else "")
+    <> "the inner ward of Akkonai."
+    <> (if unvisited x then " You exhaled—both relieved and fatigued." else "")
+    <> " A tirùnga grew from the center of the ward, its roots hidden beneath a\
+        \ blanket of fog. Stairs ran north to the keep."
+    )
+  # containing [fog, tirungaTree, roots, leaves]
 
 fog :: Object
 fog = scenery "fog"
-    "A thin layer of dense fog covered the majority of the courtyard of the\
-    \ inner ward."
+  "A thin layer of dense fog covered the majority of the courtyard of the inner\
+  \ ward."
 
 tirungaTree :: Object
 tirungaTree = scenery "tirùnga tree"
-    "The builders of the castle must have purposely built the inner ward around\
-    \ the enormous tree. Perhaps it would remain when the walls of Akkonai had\
-    \ been ground to dust by rain and wind."
+  "The builders of the castle must have purposely built the inner ward around\
+  \ the enormous tree. Perhaps it would remain when the walls of Akkonai had\
+  \ been ground to dust by rain and wind."
 
 roots :: Object
 roots = scenery "roots"
-    "The roots of the tirùnga could not be made out in the dense fog."
+  "The roots of the tirùnga could not be made out in the dense fog."
 
 leaves :: Object
 leaves = scenery "leaves"
-    "The tirùnga was prized for its blood-red leaves; it was often used as an\
-    \ ornamental plant."
-    # insteadOf taking (say "The leaves were too far above to take.")
+  "The tirùnga was prized for its blood-red leaves; it was often used as an\
+  \ ornamental plant."
+  # insteadOf taking (say "The leaves were too far above to take.")
 
 -- Section - The keep approach -------------------------------------------------
 
 keepApproach :: Place
 keepApproach = place "keep approach"
-    # withExit south "northern inner ward courtyard"
-    # withDescription "An enormous stairway lead up the craggy motte to the\
-        \ keep. It, clad in black marble, was crowned with corbels depicting\
-        \ various impish creatures. The rest of the inner ward was to the\
-        \ south."
-    # containing [corbels, fog, tirungaTree, roots, leaves]
+  # withExit south "northern inner ward courtyard"
+  # withDescription "An enormous stairway lead up the craggy motte to the keep.\
+    \ It, clad in black marble, was crowned with corbels depicting various\
+    \ impish creatures. The rest of the inner ward was to the south."
+  # containing [corbels, fog, tirungaTree, roots, leaves]
 
 corbels :: Object
 corbels = scenery "corbels"
-    "Between the arch-supporting corbels were machicolations; you imagined\
-    \ eyes watching from them."
+  "Between the arch-supporting corbels were machicolations; you imagined eyes\
+  \ watching from them."
 
 keepDoor :: Object
 keepDoor = scenery "keep door"
-    "The doors to the keep were two imposing slabs of dark metal. They lacked\
-    \any sort of handle or latch."
+  "The doors to the keep were two imposing slabs of dark metal. They lacked any\
+  \ sort of handle or latch."
 
 -- Section - The southern inner ward courtyard ---------------------------------
 
 southernInnerWardCourtyard :: Place
 southernInnerWardCourtyard = place "southern inner ward courtyard"
-    # withExits [
-        north `to` "northern inner ward courtyard",
-        east `to` "gallery",
-        west `to` "great hall",
-        south `to` "gatehouse"
-        ]
-    # withDescription "Fog covered the courtyard of the inner ward. A massive\
-        \ tirùnga punctured the center of the ward, spreading its canopy of\
-        \ crimson, spear-shaped leaves far overhead. The path to the keep lead\
-        \ north. There were structures to the east and west. To the south was\
-        \ the inner ward gate."
-    # containing [fog, tirungaTree, roots, leaves]
+  # withExits
+    [ north `to` "northern inner ward courtyard"
+    , east `to` "gallery"
+    , west `to` "great hall"
+    , south `to` "gatehouse"
+    ]
+  # withDescription "Fog covered the courtyard of the inner ward. A massive\
+    \ tirùnga punctured the center of the ward, spreading its canopy of\
+    \ crimson, spear-shaped leaves far overhead. The path to the keep lead\
+    \ north. There were structures to the east and west. To the south was the\
+    \ inner ward gate."
+  # containing [fog, tirungaTree, roots, leaves]
 
 -- Section - The library -------------------------------------------------------
 
 library :: Place
 library = place "library"
-    # withExit north "gallery"
-    # whenDescribing (\x ->
-      (if unvisited x then "You knew better than to hope the Akkonai’s\
-          \ library would be intact, but the scene disheartened you still. "
-          else "")
-      <> "The myriad shelves "
-      <> (if visited x then "of the once grand library " else "")
-      <> "had been thoroughly looted decades ago. An alcove to the east housed\
-          \  broken bench and the shattered remains of a stained glass window.\
-          \ An archway to the north lead to the gallery; the door it once\
-          \ supported lay beneath it."
-      )
-    # containing [libraryShelves, brokenBench]
+  # withExit north "gallery"
+  # whenDescribing (\x ->
+    (if unvisited x then "You knew better than to hope the Akkonai’s library\
+      \ would be intact, but the scene disheartened you still. "
+      else "")
+    <> "The myriad shelves "
+    <> (if visited x then "of the once grand library " else "")
+    <> "had been thoroughly looted decades ago. An alcove to the east housed\
+      \ broken bench and the shattered remains of a stained glass window. An\
+      \ archway to the north lead to the gallery; the door it once supported\
+      \ lay beneath it."
+    )
+  # containing [libraryShelves, brokenBench]
 
 libraryShelves :: Object
 libraryShelves = scenery "library shelves"
-    "The shelves were bare and blanketed with dust. Not even a scrap of\
-    \ parchment remained. This was the work of the Academy."
+  "The shelves were bare and blanketed with dust. Not even a scrap of parchment\
+  \ remained. This was the work of the Academy."
 
 brokenBench :: Object
 brokenBench = scenery "broken bench"
-    "It listed to one side as two of its legs were missing."
+  "It listed to one side as two of its legs were missing."
 
 libraryDoor :: Object
 libraryDoor = scenery "library door"
-    "The door had long ago fallen to the floor."
+  "The door had long ago fallen to the floor."
 
 stainedGlassWindow :: Object
 stainedGlassWindow = scenery "stained glass window"
-    "What image once adorned the window you could only guess; its shattered\
-    \ remnants let in a damp draft."
+  "What image once adorned the window you could only guess; its shattered\
+  \ remnants let in a damp draft."
 
 -- Section - The gallery -------------------------------------------------------
 
 gallery :: Place
 gallery = place "gallery"
-    # withExits [
-        west `to` "southern inner ward courtyard",
-        north `to` "gallery",
-        south `to` "library"
-        ]
-    # withDescription "The walls were bare, save for a few broken picture\
-        \ frames and a lone intact painting weathered beyond recognition. An\
-        \ archway lead to the south. To the west was the inner ward courtyard."
-    # containing [galleryWalls, brokenPictureFrames, archway]
+  # withExits
+    [ west `to` "southern inner ward courtyard"
+    , north `to` "gallery"
+    , south `to` "library"
+    ]
+  # withDescription "The walls were bare, save for a few broken picture\
+    \ frames and a lone intact painting weathered beyond recognition. An\
+    \ archway lead to the south. To the west was the inner ward courtyard."
+  # containing [galleryWalls, brokenPictureFrames, archway]
 
 galleryWalls :: Object
 galleryWalls = scenery "gallery walls"
-    "You imagined the walls of the gallery once held portraits of the many\
-    \ masters of Akkonai."
+  "You imagined the walls of the gallery once held portraits of the many\
+  \ masters of Akkonai."
 
 brokenPictureFrames :: Object
 brokenPictureFrames = scenery "broken picture frames"
-    "Someone had purposely destroyed the images contained therein."
+  "Someone had purposely destroyed the images contained therein."
 
 archway :: Object
 archway = scenery "archway"
-    "Chiseled into the arch was “hwaptrâ”, the Akettan word for library."
+  "Chiseled into the arch was “hwaptrâ”, the Akettan word for library."
 
 painting :: Object
 painting = scenery "painting"
-    "Though the image itself had been destroyed by natural forces, the canvas\
-    \ seemed somehow untouched by rot."
+  "Though the image itself had been destroyed by natural forces, the canvas\
+  \ seemed somehow untouched by rot."
 
 canvas :: Object
 canvas = object "canvas"
-    "The canvas had somehow survived the ravages of nature; you suspected\
-    \ alchemy. Written on the back of the canvas was “shúrâ kâmârât”. You had\
-    \ no inkling as to what that meant."
+  "The canvas had somehow survived the ravages of nature; you suspected\
+  \ alchemy. Written on the back of the canvas was “shúrâ kâmârât”. You had no\
+  \ inkling as to what that meant."
 
 -- Section - The great hall ----------------------------------------------------
 
 greatHall :: Place
 greatHall = place "great hall"
-    -- # interior
-    # withExits [east `to` "southern inner ward courtyard", west `to` "kitchen"]
-    # withDescription "A hall that could once seat hundreds was reduced to a\
-        \ pit of detritus. Great tables were crushed beneath collapsing plaster\
-        \ and stonework. The dais, waterlogged and rotten, sagged in the\
-        \ middle. Surrounding the room were three huge fireplaces, though their\
-        \ flues were likely choked with rubble. A small doorway to the west\
-        \ lead to a kitchen. To the east was the courtyard of the inner ward."
-    # containing [dais, tables, fireplaces, doorway]
+  # withExits [east `to` "southern inner ward courtyard", west `to` "kitchen"]
+  # withDescription "A hall that could once seat hundreds was reduced to a pit\
+    \ of detritus. Great tables were crushed beneath collapsing plaster and\
+    \ stonework. The dais, waterlogged and rotten, sagged in the middle.\
+    \ Surrounding the room were three huge fireplaces, though their flues were\
+    \ likely choked with rubble. A small doorway to the west lead to a kitchen.\
+    \ To the east was the courtyard of the inner ward."
+  # containing [dais, tables, fireplaces, doorway]
 
 dais :: Object
 dais = scenery "dais"
-    "The dais was rotting."
+  "The dais was rotting."
 
 tables :: Object
 tables = scenery "tables"
-    "You wondered if this hall had ever been full."
+  "You wondered if this hall had ever been full."
 
 fireplaces :: Object
 fireplaces = scenery "fireplaces"
-    "None of the fireplaces remained functional."
+  "None of the fireplaces remained functional."
 
 doorway :: Object
 doorway = scenery "doorway"
-    "You could not make out what was on the other side."
+  "You could not make out what was on the other side."
 
 -- Section - The kitchen -------------------------------------------------------
 
 kitchen :: Place
 kitchen = place "kitchen"
-    # withExits [east `to` "great hall", north `to` "larder"]
-    # withDescription "The larder was to the north. The great hall was to the\
+  # withExits [east `to` "great hall", north `to` "larder"]
+  # withDescription "The larder was to the north. The great hall was to the\
     \ east."
-    # containing [knife]
+  # containing [knife]
 
 knife :: Object
 knife = object "knife"
-    "The tapered blade was thoroughly coated with rust; the knife’s handle,\
-    \ however, was intact."
+  "The tapered blade was thoroughly coated with rust; the knife’s handle,\
+  \ however, was intact."
 
 -- Section - The larder --------------------------------------------------------
 
 larder :: Place
 larder = place "larder"
-    # withExit south "kitchen"
-    # withDescription "The larder was bare save for a pile of torn sacks of\
-        \ grain. Rodent droppings were apparent everywhere. The kitchen was to\
-        \ the south."
-    # containing [rodentDroppings, cobwebs, larderShelves, sacksOfGrain]
+  # withExit south "kitchen"
+  # withDescription "The larder was bare save for a pile of torn sacks of\
+    \ grain. Rodent droppings were apparent everywhere. The kitchen was to the\
+    \ south."
+  # containing [rodentDroppings, cobwebs, larderShelves, sacksOfGrain]
 
 rodentDroppings :: Object
 rodentDroppings = scenery "rodent droppings"
-    "You wrinkled your nose."
+  "You wrinkled your nose."
 
 cobwebs :: Object
 cobwebs = scenery "cobwebs"
-    "Cobwebs decorated the ceiling of the larder and cascaded down its bare\
-    \ shelves."
+  "Cobwebs decorated the ceiling of the larder and cascaded down its bare\
+  \ shelves."
 
 larderShelves :: Object
 larderShelves = scenery "larder shelves"
-    "The shelves were empty of everything but dust cobwebs."
+  "The shelves were empty of everything but dust cobwebs."
 
 sacksOfGrain :: Object
 sacksOfGrain = scenery "sacks of grain"
-    "The sacks were empty and scattered about carelessly."
+  "The sacks were empty and scattered about carelessly."
 
 -- Section - The gatehouse -----------------------------------------------------
 
 gatehouse :: Place
 gatehouse = place "gatehouse"
-    # withExits [
-        north `to` "southern inner ward courtyard",
-        south `to` "outer ward courtyard"
-        ]
-    # withDescription "The gatehouse separated the inner ward (to the north)\
-        \ from the outer ward (to the south)."
+  # withExits
+    [ north `to` "southern inner ward courtyard"
+    , south `to` "outer ward courtyard"
+    ]
+  # withDescription "The gatehouse separated the inner ward (to the north) from\
+    \ the outer ward (to the south)."
 
 -- Section - The outer ward courtyard ------------------------------------------
 
 outerWardCourtyard :: Place
 outerWardCourtyard = place "outer ward courtyard"
-    # withExits [north `to` "gatehouse"]
-    # withDescription "A yawning chasm sundered the outer ward. The gate to\
-        \ the inner ward was to the north."
+  # withExits [north `to` "gatehouse"]
+  # withDescription "A yawning chasm sundered the outer ward. The gate to the\
+    \ inner ward was to the north."

--- a/src/Skald.purs
+++ b/src/Skald.purs
@@ -4,34 +4,34 @@
 -- http://opensource.org/licenses/MIT>. This file may not be copied, modified,
 -- or distributed except according to those terms.
 
-module Skald (
-    -- * Applications
-    module Skald.Application,
+module Skald
+  ( -- * Applications
+    module Skald.Application
 
-    -- * Tales
-    module Skald.Tale,
+  -- * Tales
+  , module Skald.Tale
 
-    -- * Worlds
-    module Skald.World,
+  -- * Worlds
+  , module Skald.World
 
-    -- * Places
-    module Skald.Place,
-    module Skald.PlaceBuilder,
+  -- * Places
+  , module Skald.Place
+  , module Skald.PlaceBuilder
 
-    -- * Objects
-    module Skald.Object,
+  -- * Objects
+  , module Skald.Object
 
-    -- * Actions
-    module Skald.Action,
+  -- * Actions
+  , module Skald.Action
 
-    -- * Directions
-    module Skald.Direction,
+  -- * Directions
+  , module Skald.Direction
 
-    -- * Useful re-exports
-    module Prelude,
-    module Data.List,
-    module Data.Maybe
-    ) where
+  -- * Useful re-exports
+  , module Prelude
+  , module Data.List
+  , module Data.Maybe
+  ) where
 
 import Prelude (
     class Applicative, pure, liftA1, unless, when,

--- a/src/Skald.purs
+++ b/src/Skald.purs
@@ -33,64 +33,56 @@ module Skald
   , module Data.Maybe
   ) where
 
-import Prelude (
-    class Applicative, pure, liftA1, unless, when,
-    class Apply, apply, (*>), (<*), (<*>),
-    class Bind, bind, ifM, join, (<=<), (=<<), (>=>), (>>=),
-    class Category, id,
-    class Monad, ap, liftM1,
-    class Semigroupoid, compose, (<<<), (>>>),
-    otherwise,
-    class BooleanAlgebra,
-    class Bounded, bottom, top,
-    class CommutativeRing,
-    class Eq, eq, notEq, (/=), (==),
-    class EuclideanRing, degree, div, mod, (/),
-    class Field,
-    const, flip, ($), (#),
-    class Functor, map, void, ($>), (<#>), (<$), (<$>),
-    class HeytingAlgebra, conj, disj, not, (&&), (||),
-    type (~>),
-    class Ord, compare, (<), (<=), (>), (>=), comparing, min, max, clamp,
-    between,
-    Ordering (..),
-    class Ring, negate, sub, (-),
-    class Semigroup, append, (<>),
-    class Semiring, add, mul, one, zero, (*), (+),
-    class Show, show,
-    Unit, unit,
-    Void, absurd
-    )
-
-import Data.List (List (..), (:))
-import Data.Maybe (
-    Maybe (..), maybe, maybe', fromMaybe, fromMaybe', isJust, isNothing
-    )
-
-import Skald.Action (
-    Action, say, sayError, doNothing, describeObject, describePlace,
-    removeFromInventory, createObject,
-
-    looking, look,
-    searching, search,
-    going, go,
-    taking, take,
-    takingInventory, takeInventory,
-    dropping, drop,
-    waiting, wait
-    )
+import Prelude
+  ( class Applicative, pure, liftA1, unless, when
+  , class Apply, apply, (*>), (<*), (<*>)
+  , class Bind, bind, ifM, join, (<=<), (=<<), (>=>), (>>=)
+  , class Category, id
+  , class Monad, ap, liftM1
+  , class Semigroupoid, compose, (<<<), (>>>)
+  , otherwise
+  , class BooleanAlgebra
+  , class Bounded, bottom, top
+  , class CommutativeRing
+  , class Eq, eq, notEq, (/=), (==)
+  , class EuclideanRing, degree, div, mod, (/)
+  , class Field
+  , const, flip, ($), (#)
+  , class Functor, map, void, ($>), (<#>), (<$), (<$>)
+  , class HeytingAlgebra, conj, disj, not, (&&), (||)
+  , type (~>)
+  , class Ord, compare, (<), (<=), (>), (>=), comparing, min, max, clamp
+  , between
+  , Ordering(..)
+  , class Ring, negate, sub, (-)
+  , class Semigroup, append, (<>)
+  , class Semiring, add, mul, one, zero, (*), (+)
+  , class Show, show
+  , Unit, unit
+  , Void, absurd
+  )
+import Data.List (List(..), (:))
+import Data.Maybe
+  ( Maybe(..), maybe, maybe', fromMaybe, fromMaybe', isJust, isNothing
+  )
+import Skald.Action
+  ( Action, say, sayError, doNothing, describeObject, describePlace
+  , removeFromInventory, createObject, looking, look, searching, search, going
+  , go, taking, take, takingInventory, takeInventory, dropping, drop, waiting
+  , wait
+  )
 import Skald.Application (Application, Effects, run)
-import Skald.Direction (
-    Direction, north, northeast, east, southeast, south, southwest, west,
-    northwest, up, down
-    )
+import Skald.Direction
+  ( Direction, north, northeast, east, southeast, south, southwest, west
+  , northwest, up, down
+  )
 import Skald.Object (Object, object, scenery, insteadOf)
 import Skald.Place (Place, place, visited, unvisited)
-import Skald.PlaceBuilder (
-    withDescription, whenDescribing, withExit, withExits, to, containing
-    )
-import Skald.Tale (
-    Tale, tale, title, author, initialWorld, preamble, by, withPreamble,
-    thatBeginsIn, withPlace, withPlaces, withCommand
-    )
+import Skald.PlaceBuilder
+  ( withDescription, whenDescribing, withExit, withExits, to, containing
+  )
+import Skald.Tale
+  ( Tale, tale, title, author, initialWorld, preamble, by, withPreamble
+  , thatBeginsIn, withPlace, withPlaces, withCommand
+  )
 import Skald.World (World, inventory, item)

--- a/src/Skald/Action.purs
+++ b/src/Skald/Action.purs
@@ -32,13 +32,11 @@ module Skald.Action
   ) where
 
 import Prelude
-
 import Control.Monad.State as State
 import Control.Monad.Writer as Writer
-import Data.List (List (..), (:))
-import Data.Maybe (Maybe (..))
+import Data.List (List(..), (:))
+import Data.Maybe (Maybe(..))
 import Data.Monoid (mempty)
-
 import Skald.Command as Command
 import Skald.Command (Command, command)
 import Skald.Debug (debug)

--- a/src/Skald/Action.purs
+++ b/src/Skald/Action.purs
@@ -4,26 +4,32 @@
 -- http://opensource.org/licenses/MIT>. This file may not be copied, modified,
 -- or distributed except according to those terms.
 
-module Skald.Action (
-    module Skald.Internal,
-    enterPlace,
-    doNothing,
-    say,
-    sayError,
-    emptyWorld,
-    describePlace,
-    describeObject,
-    removeFromInventory,
-    createObject,
-
-    looking, look,
-    searching, search,
-    going, go,
-    taking, take,
-    takingInventory, takeInventory,
-    dropping, drop,
-    waiting, wait
-    ) where
+module Skald.Action
+  ( module Skald.Internal
+  , enterPlace
+  , doNothing
+  , say
+  , sayError
+  , emptyWorld
+  , describePlace
+  , describeObject
+  , removeFromInventory
+  , createObject
+  , looking
+  , look
+  , searching
+  , search
+  , going
+  , go
+  , taking
+  , take
+  , takingInventory
+  , takeInventory
+  , dropping
+  , drop
+  , waiting
+  , wait
+  ) where
 
 import Prelude
 

--- a/src/Skald/Application.purs
+++ b/src/Skald/Application.purs
@@ -11,7 +11,6 @@ module Skald.Application
   ) where
 
 import Prelude
-
 import Control.Monad.Aff (Aff)
 import Control.Monad.Aff.Free (fromEff)
 import Control.Monad.Eff (Eff)
@@ -43,14 +42,14 @@ type Application = Eff (Effects ()) Unit
 type Effects eff = H.HalogenEffects (focus :: FOCUS | eff)
 
 data Query a
-    = UpdateDescription String a
-    | Submit String a
+  = UpdateDescription String a
+  | Submit String a
 
 -- | Tell the given tale.
 run :: Tale -> Application
 run tale = runHalogenAff do
-    body <- awaitBody
-    H.runUI (ui tale) (startUp tale) body
+  body <- awaitBody
+  H.runUI (ui tale) (startUp tale) body
 
 ui :: forall eff. Tale -> H.Component Model Query (Aff (Effects eff))
 ui tale = H.component { render, eval }
@@ -83,35 +82,35 @@ ui tale = H.component { render, eval }
 -- | Renders history to an array of HTML elements.
 renderHistory :: forall a. History -> Array (H.ComponentHTML a)
 renderHistory =
-    Array.fromFoldable <<< map renderHistoricalEntry <<< History.toList
+  Array.fromFoldable <<< map renderHistoricalEntry <<< History.toList
 
 -- | Renders a historical entry to an HTML element.
 renderHistoricalEntry :: forall a. HistoricalEntry -> H.ComponentHTML a
 renderHistoricalEntry entry =
-    HH.p attributes [HH.text (Tuple.snd classAndString)]
-    where
-        classAndString = case entry of
-           Message string -> Tuple "message" string
-           Echo string -> Tuple "echo" string
-           Heading string -> Tuple "heading" string
-           Error string -> Tuple "error" string
-           Debug string -> Tuple "debug" string
-        attributes = [HP.class_ (HH.className (Tuple.fst classAndString))]
+  HH.p attributes [HH.text (Tuple.snd classAndString)]
+  where
+    classAndString = case entry of
+      Message string -> Tuple "message" string
+      Echo string -> Tuple "echo" string
+      Heading string -> Tuple "heading" string
+      Error string -> Tuple "error" string
+      Debug string -> Tuple "debug" string
+    attributes = [HP.class_ (HH.className (Tuple.fst classAndString))]
 
 -- | Submits the contents of the input field to the command parser.
 update :: String -> Model -> Model
 update field model = case runState (execWriterT (Command.parse field)) (Model.world model) of
-    Tuple commandResult newWorld ->
-        Model.setWorld newWorld
-        $ Model.appendHistory (History.cons (History.echo field) commandResult)
-        $ model
+  Tuple commandResult newWorld ->
+    Model.setWorld newWorld
+    $ Model.appendHistory (History.cons (History.echo field) commandResult)
+    $ model
 
 startUp :: Tale -> Model
 startUp tale = case runState (execWriterT onStartUp) world of
-    Tuple description newWorld ->
-        Model.setWorld newWorld
-        $ Model.setHistory description
-        $ Model.empty
-    where
-        world = Tale.initialWorld tale
-        onStartUp = Action.enterPlace (World.currentPlace world)
+  Tuple description newWorld ->
+      Model.setWorld newWorld
+      $ Model.setHistory description
+      $ Model.empty
+  where
+    world = Tale.initialWorld tale
+    onStartUp = Action.enterPlace (World.currentPlace world)

--- a/src/Skald/Application.purs
+++ b/src/Skald/Application.purs
@@ -20,18 +20,17 @@ import Control.Monad.Writer.Trans (execWriterT)
 import Data.Array as Array
 import Data.List ((:))
 import Data.Tuple as Tuple
-import Data.Tuple (Tuple (..))
+import Data.Tuple (Tuple(..))
 import Halogen as H
 import Halogen.HTML.Events.Indexed as HE
 import Halogen.HTML.Indexed as HH
 import Halogen.HTML.Properties.Indexed as HP
 import Halogen.Util (awaitBody, runHalogenAff)
-
 import Skald.Action as Action
 import Skald.Command as Command
 import Skald.History as History
 import Skald.History (History)
-import Skald.Internal (HistoricalEntry (..))
+import Skald.Internal (HistoricalEntry(..))
 import Skald.Focus (FOCUS, focus)
 import Skald.Model as Model
 import Skald.Model (Model)

--- a/src/Skald/Application.purs
+++ b/src/Skald/Application.purs
@@ -4,11 +4,11 @@
 -- http://opensource.org/licenses/MIT>. This file may not be copied, modified,
 -- or distributed except according to those terms.
 
-module Skald.Application (
-    Application,
-    Effects,
-    run
-    ) where
+module Skald.Application
+  ( Application
+  , Effects
+  , run
+  ) where
 
 import Prelude
 

--- a/src/Skald/Command.purs
+++ b/src/Skald/Command.purs
@@ -14,7 +14,6 @@ module Skald.Command
   ) where
 
 import Prelude
-
 import Control.Monad.Eff.Exception.Unsafe (unsafeThrow)
 import Control.Monad.State (get)
 import Control.Monad.Writer as Writer
@@ -40,11 +39,10 @@ type Handler = CommandHandler
 type Map = CommandMap
 
 command :: String -> Command
-command string =
-    case regex ("^(?:" <> string <> ")$") Regex.noFlags of
-        Right regex' -> Command string regex'
-        -- TODO: don't do this.
-        Left error -> unsafeThrow "invalid regex"
+command string = case regex ("^(?:" <> string <> ")$") Regex.noFlags of
+  Right regex' -> Command string regex'
+  -- TODO: don't do this.
+  Left error -> unsafeThrow "invalid regex"
 
 -- | Inserts a command handler into the given command map.
 insert :: Command -> Handler -> Map -> Map
@@ -54,49 +52,49 @@ insert command' handler map' = Tuple command' handler : map'
 -- | Parses a command string and returns the corresponding `Action`.
 parse :: String -> Action Unit
 parse field = do
-    world <- get
-    -- TODO: this isn't lazy any more! Stop after first match.
-    case List.head (List.filter predicate (map matcher (World.commands world))) of
-        Just (Tuple command' (Tuple (Just matches) action)) -> do
-            let submatches = case List.tail (catMaybes (List.fromFoldable matches)) of
-                    Just x -> x
-                    -- TODO: this should be impossible.
-                    Nothing -> Nil
-            -- TODO: this is a dirty hack. We match the object just to throw it
-            -- away, which seems fruitless (why not pass it on to the action?)
-            -- Furthermore, it assumes every command operates over a single
-            -- object as opposed to other things. Commands need an overhaul.
-            case submatches of
-                x : _ ->
-                    case Place.object x (World.currentPlace world) of
-                        Just directObject ->
-                            case Object.command command' directObject of
-                                Just y -> y
-                                Nothing -> action submatches
-                        Nothing -> action submatches
-                Nil ->  action submatches
-        _ -> do
-            sayParserError "Unrecognized command."
-    where
-        field' = normalizeWhitespace (String.toLower field)
-        matcher (Tuple command'@(Command string regex) action) =
-            Tuple command' (Tuple (Regex.match regex field') action)
-        predicate (Tuple _ (Tuple x _)) = Maybe.isJust x
+  world <- get
+  -- TODO: this isn't lazy any more! Stop after first match.
+  case List.head (List.filter predicate (map matcher (World.commands world))) of
+    Just (Tuple command' (Tuple (Just matches) action)) -> do
+      let submatches = case List.tail (catMaybes (List.fromFoldable matches)) of
+            Just x -> x
+            -- TODO: this should be impossible.
+            Nothing -> Nil
+      -- TODO: this is a dirty hack. We match the object just to throw it
+      -- away, which seems fruitless (why not pass it on to the action?)
+      -- Furthermore, it assumes every command operates over a single
+      -- object as opposed to other things. Commands need an overhaul.
+      case submatches of
+        x : _ ->
+          case Place.object x (World.currentPlace world) of
+            Just directObject ->
+              case Object.command command' directObject of
+                Just y -> y
+                Nothing -> action submatches
+            Nothing -> action submatches
+        Nil ->  action submatches
+    _ -> do
+        sayParserError "Unrecognized command."
+  where
+    field' = normalizeWhitespace (String.toLower field)
+    matcher (Tuple command'@(Command string regex) action) =
+        Tuple command' (Tuple (Regex.match regex field') action)
+    predicate (Tuple _ (Tuple x _)) = Maybe.isJust x
 
 normalizeWhitespace :: String -> String
 normalizeWhitespace = Regex.replace whitespaceRegex " "
-    where
-        whitespaceRegex = case regex "\\s+" Regex.noFlags of
-            Right regex' -> regex'
-            -- NOTE: This cannot occur.
-            Left error -> unsafeThrow "normalizeWhitespace failed."
+  where
+    whitespaceRegex = case regex "\\s+" Regex.noFlags of
+      Right regex' -> regex'
+      -- NOTE: This cannot occur.
+      Left error -> unsafeThrow "normalizeWhitespace failed."
 
 -- TODO: move.
 catMaybes :: forall a. List (Maybe a) -> List a
 catMaybes = case _ of
-    Nil -> Nil
-    Nothing : xs -> catMaybes xs
-    Just x : xs -> x : catMaybes xs
+  Nil -> Nil
+  Nothing : xs -> catMaybes xs
+  Just x : xs -> x : catMaybes xs
 
 sayParserError :: String -> Action Unit
 sayParserError = Writer.tell <<< History.singleton <<< formatParserError

--- a/src/Skald/Command.purs
+++ b/src/Skald/Command.purs
@@ -18,20 +18,19 @@ import Prelude
 import Control.Monad.Eff.Exception.Unsafe (unsafeThrow)
 import Control.Monad.State (get)
 import Control.Monad.Writer as Writer
-import Data.Either (Either (..))
+import Data.Either (Either(..))
 import Data.List as List
-import Data.List (List (..), (:))
+import Data.List (List(..), (:))
 import Data.Maybe as Maybe
-import Data.Maybe (Maybe (..))
+import Data.Maybe (Maybe(..))
 import Data.String as String
 import Data.String.Regex as Regex
 import Data.String.Regex (regex)
-import Data.Tuple (Tuple (..))
-
+import Data.Tuple (Tuple(..))
 import Skald.History as History
 import Skald.History (HistoricalEntry)
 import Skald.Internal (Command) as InternalExports
-import Skald.Internal (Action, Command (..), CommandHandler, CommandMap)
+import Skald.Internal (Action, Command(..), CommandHandler, CommandMap)
 import Skald.Object as Object
 import Skald.Place as Place
 import Skald.World as World

--- a/src/Skald/Command.purs
+++ b/src/Skald/Command.purs
@@ -4,14 +4,14 @@
 -- http://opensource.org/licenses/MIT>. This file may not be copied, modified,
 -- or distributed except according to those terms.
 
-module Skald.Command (
-    module InternalExports,
-    Handler,
-    Map,
-    command,
-    insert,
-    parse
-    ) where
+module Skald.Command
+  ( module InternalExports
+  , Handler
+  , Map
+  , command
+  , insert
+  , parse
+  ) where
 
 import Prelude
 

--- a/src/Skald/Debug.purs
+++ b/src/Skald/Debug.purs
@@ -4,10 +4,10 @@
 -- http://opensource.org/licenses/MIT>. This file may not be copied, modified,
 -- or distributed except according to those terms.
 
-module Skald.Debug (
-    class Debug,
-    debug
-    ) where
+module Skald.Debug
+  ( class Debug
+  , debug
+  ) where
 
 import Prelude
 

--- a/src/Skald/Debug.purs
+++ b/src/Skald/Debug.purs
@@ -17,7 +17,7 @@ import Data.Map (Map)
 import Data.String as String
 import Data.StrMap as StrMap
 import Data.StrMap (StrMap)
-import Data.Tuple (Tuple (..))
+import Data.Tuple (Tuple(..))
 
 class Debug a where
     debug :: a -> String

--- a/src/Skald/Debug.purs
+++ b/src/Skald/Debug.purs
@@ -20,34 +20,34 @@ import Data.StrMap (StrMap)
 import Data.Tuple (Tuple(..))
 
 class Debug a where
-    debug :: a -> String
+  debug :: a -> String
 
 instance debugBoolean :: Debug Boolean where
-    debug = show
+  debug = show
 
 instance debugInt :: Debug Int where
-    debug = show
+  debug = show
 
 instance debugNumber :: Debug Number where
-    debug = show
+  debug = show
 
 instance debugChar :: Debug Char where
-    debug = show
+  debug = show
 
 instance debugString :: Debug String where
-    debug = show
+  debug = show
 
 instance debugTuple :: (Debug a, Debug b) => Debug (Tuple a b) where
-    debug (Tuple a b) = "Tuple " <> debug a <> " " <> debug b
+  debug (Tuple a b) = "Tuple " <> debug a <> " " <> debug b
 
 instance debugArray :: Debug a => Debug (Array a) where
-    debug x = "[" <> String.joinWith ", " (map debug x) <> "]"
+  debug x = "[" <> String.joinWith ", " (map debug x) <> "]"
 
 instance debugFunction :: Debug (a -> b) where
-    debug _ = "<?>"
+  debug _ = "<?>"
 
 instance debugStrMap :: Debug a => Debug (StrMap a) where
-    debug x = debug (Array.fromFoldable (StrMap.toList x))
+  debug x = debug (Array.fromFoldable (StrMap.toList x))
 
 instance debugMap :: (Debug a, Debug b) => Debug (Map a b) where
-    debug x = debug (Array.fromFoldable (Map.toList x))
+  debug x = debug (Array.fromFoldable (Map.toList x))

--- a/src/Skald/Direction.purs
+++ b/src/Skald/Direction.purs
@@ -29,70 +29,70 @@ import Data.Maybe (Maybe(..))
 import Skald.Debug (class Debug)
 
 data Direction
-    = North
-    | Northeast
-    | East
-    | Southeast
-    | South
-    | Southwest
-    | West
-    | Northwest
-    | Up
-    | Down
+  = North
+  | Northeast
+  | East
+  | Southeast
+  | South
+  | Southwest
+  | West
+  | Northwest
+  | Up
+  | Down
 
 derive instance genericDirection :: Generic Direction
 
 instance eqDirection :: Eq Direction where
-    eq = gEq
+  eq = gEq
 
 instance ordDirection :: Ord Direction where
-    compare = gCompare
+  compare = gCompare
 
 instance showDirection :: Show Direction where
-    show direction = case direction of
-        North -> "north"
-        Northeast -> "northeast"
-        East -> "east"
-        Southeast -> "southeast"
-        South -> "south"
-        Southwest -> "southwest"
-        West -> "west"
-        Northwest -> "northwest"
-        Up -> "up"
-        Down -> "down"
+  show = case _ of
+    North -> "north"
+    Northeast -> "northeast"
+    East -> "east"
+    Southeast -> "southeast"
+    South -> "south"
+    Southwest -> "southwest"
+    West -> "west"
+    Northwest -> "northwest"
+    Up -> "up"
+    Down -> "down"
 
 instance debugDirection :: Debug Direction where
-    debug = show
+  debug = show
 
 -- | The corresponding direction for the given string, if the string is the name
 -- of a lower case cardinal direction.
 fromString :: String -> Maybe Direction
-fromString string = case string of
-    "north" -> Just North
-    "northeast" -> Just Northeast
-    "east" -> Just East
-    "southeast" -> Just Southeast
-    "south" -> Just South
-    "southwest" -> Just Southwest
-    "west" -> Just West
-    "northwest" -> Just Northwest
-    "up" -> Just Up
-    "down" -> Just Down
-    _ -> Nothing
+fromString = case _ of
+  "north" -> Just North
+  "northeast" -> Just Northeast
+  "east" -> Just East
+  "southeast" -> Just Southeast
+  "south" -> Just South
+  "southwest" -> Just Southwest
+  "west" -> Just West
+  "northwest" -> Just Northwest
+  "up" -> Just Up
+  "down" -> Just Down
+  _ -> Nothing
 
 -- | The direction opposite the given direction.
 opposite :: Direction -> Direction
-opposite direction = case direction of
-    North -> South
-    Northeast -> Southwest
-    East -> West
-    Southeast -> Northwest
-    South -> North
-    Southwest -> Northeast
-    West -> East
-    Northwest -> Southeast
-    Up -> Down
-    Down -> Up
+opposite = case _ of
+  North -> South
+  Northeast -> Southwest
+  East -> West
+  Southeast -> Northwest
+  South -> North
+  Southwest -> Northeast
+  West -> East
+  Northwest -> Southeast
+  Up -> Down
+  Down -> Up
 
 -- | The direction north.
 north :: Direction

--- a/src/Skald/Direction.purs
+++ b/src/Skald/Direction.purs
@@ -5,21 +5,21 @@
 -- or distributed except according to those terms.
 
 -- | Contains the data type for the cardinal directions.
-module Skald.Direction (
-    Direction (..),
-    fromString,
-    opposite,
-    north,
-    northeast,
-    east,
-    southeast,
-    south,
-    southwest,
-    west,
-    northwest,
-    up,
-    down
-    ) where
+module Skald.Direction
+  ( Direction(..)
+  , fromString
+  , opposite
+  , north
+  , northeast
+  , east
+  , southeast
+  , south
+  , southwest
+  , west
+  , northwest
+  , up
+  , down
+  ) where
 
 import Prelude
 

--- a/src/Skald/Direction.purs
+++ b/src/Skald/Direction.purs
@@ -24,7 +24,7 @@ module Skald.Direction
 import Prelude
 
 import Data.Generic (class Generic, gCompare, gEq)
-import Data.Maybe (Maybe (..))
+import Data.Maybe (Maybe(..))
 
 import Skald.Debug (class Debug)
 

--- a/src/Skald/Focus.purs
+++ b/src/Skald/Focus.purs
@@ -11,7 +11,6 @@ module Skald.Focus
   ) where
 
 import Prelude
-
 import Control.Monad.Eff (Eff)
 
 foreign import data FOCUS :: !

--- a/src/Skald/Focus.purs
+++ b/src/Skald/Focus.purs
@@ -5,10 +5,10 @@
 -- or distributed except according to those terms.
 
 -- TODO: rename module?
-module Skald.Focus (
-    FOCUS,
-    focus
-    ) where
+module Skald.Focus
+  ( FOCUS
+  , focus
+  ) where
 
 import Prelude
 

--- a/src/Skald/History.purs
+++ b/src/Skald/History.purs
@@ -31,7 +31,7 @@ cons entry (History history) = History (entry : history)
 
 -- | Create a new history from a historical entry list.
 fromList :: List HistoricalEntry -> History
-fromList list = History list
+fromList = History
 
 -- | Create a historical entry list from the given history.
 toList :: History -> List HistoricalEntry

--- a/src/Skald/History.purs
+++ b/src/Skald/History.purs
@@ -8,18 +8,18 @@
 --
 -- "History" is the name for in-tale messages, error messages, and echoed
 -- player input generated during the telling of a tale.
-module Skald.History (
-    module InternalExports,
-    cons,
-    fromList,
-    toList,
-    singleton,
-    message,
-    echo,
-    heading,
-    error,
-    debug
-    ) where
+module Skald.History
+  ( module InternalExports
+  , cons
+  , fromList
+  , toList
+  , singleton
+  , message
+  , echo
+  , heading
+  , error
+  , debug
+  ) where
 
 import Data.List (List (..), (:))
 

--- a/src/Skald/History.purs
+++ b/src/Skald/History.purs
@@ -21,10 +21,9 @@ module Skald.History
   , debug
   ) where
 
-import Data.List (List (..), (:))
-
+import Data.List (List(..), (:))
 import Skald.Internal (History, HistoricalEntry) as InternalExports
-import Skald.Internal (History (..), HistoricalEntry (..))
+import Skald.Internal (History(..), HistoricalEntry(..))
 
 -- | Add a historical entry to the beginning of the given history.
 cons :: HistoricalEntry -> History -> History

--- a/src/Skald/Internal.purs
+++ b/src/Skald/Internal.purs
@@ -5,22 +5,22 @@
 -- or distributed except according to those terms.
 
 -- | Defines mutally-recursively data types.
-module Skald.Internal (
-    Object (..),
-    ObjectCommands,
-    Place (..),
-    Exits (..),
-    Objects (..),
-    World (..),
-    Command (..),
-    CommandHandler,
-    CommandMap,
-    Action,
-    Places (..),
-    Inventory (..),
-    History (..),
-    HistoricalEntry (..)
-    ) where
+module Skald.Internal
+  ( Object(..)
+  , ObjectCommands
+  , Place(..)
+  , Exits(..)
+  , Objects(..)
+  , World(..)
+  , Command(..)
+  , CommandHandler
+  , CommandMap
+  , Action
+  , Places(..)
+  , Inventory(..)
+  , History(..)
+  , HistoricalEntry(..)
+  ) where
 
 import Prelude
 

--- a/src/Skald/Internal.purs
+++ b/src/Skald/Internal.purs
@@ -36,83 +36,83 @@ import Data.Tuple (Tuple)
 import Skald.Debug (class Debug, debug)
 import Skald.Direction (Direction)
 
-data Object = Object {
-    name :: String,
-    description :: String,
-    fixedInPlace :: Boolean,
-    commands :: ObjectCommands
-    }
+data Object = Object
+  { name :: String
+  , description :: String
+  , fixedInPlace :: Boolean
+  , commands :: ObjectCommands
+  }
 
 instance debugObject :: Debug Object where
-    debug (Object { name, description, fixedInPlace, commands }) =
-        "Object\n\
-        \    { name = " <> debug name <> "\n\
-        \    , description = " <> debug description <> "\n\
-        \    , fixedInPlace = " <> debug fixedInPlace <> "\n\
-        \    , commands = " <> "<?>" <> "\n\
-        \    }"
+  debug (Object { name, description, fixedInPlace, commands }) =
+    "Object\n\
+    \  { name = " <> debug name <> "\n\
+    \  , description = " <> debug description <> "\n\
+    \  , fixedInPlace = " <> debug fixedInPlace <> "\n\
+    \  , commands = " <> "<?>" <> "\n\
+    \  }"
 
 -- TODO: Think of snappier name.
 -- TODO: wrap in newtype.
 type ObjectCommands = Map Command (Action Unit)
 
-data Place = Place {
-    name :: String,
-    describer :: Place -> String,
-    exits :: Exits,
-    objects :: Objects,
-    visited :: Boolean
-    }
+data Place = Place
+  { name :: String
+  , describer :: Place -> String
+  , exits :: Exits
+  , objects :: Objects
+  , visited :: Boolean
+  }
 
 instance debugPlace :: Debug Place where
-    debug (Place { name, describer, exits, objects, visited }) =
-        "place " <> debug name <> "\n\
-        \    # withDescription " <> debug describer <> "\n\
-        \    # withExits " <> debug exits <> "\n\
-        \    # containing " <> debug objects <> "\n"
+  debug (Place { name, describer, exits, objects, visited }) =
+    "place " <> debug name <> "\n\
+    \  # withDescription " <> debug describer <> "\n\
+    \  # withExits " <> debug exits <> "\n\
+    \  # containing " <> debug objects <> "\n"
 
 newtype Exits = Exits (Map Direction String)
 
 instance eqExits :: Eq Exits where
-    eq (Exits a) (Exits b) = eq a b
+  eq (Exits a) (Exits b) = eq a b
 
 instance showExits :: Show Exits where
-    show (Exits a) = "Exits (" <> show a <> ")"
+  show (Exits a) = "Exits (" <> show a <> ")"
 
 instance debugExits :: Debug Exits where
-    debug (Exits a) = debug a
+  debug (Exits a) = debug a
 
 newtype Objects = Objects (StrMap Object)
 
 instance debugObjects :: Debug Objects where
-    debug (Objects objects) = debug objects
+  debug (Objects objects) = debug objects
 
-data World = World {
-    currentPlaceName :: String,
-    places :: Places,
-    commands :: CommandMap,
-    inventory :: Inventory
-    }
+data World = World
+  { currentPlaceName :: String
+  , places :: Places
+  , commands :: CommandMap
+  , inventory :: Inventory
+  }
 
 instance debugWorld :: Debug World where
-    debug (World { currentPlaceName, places, commands, inventory }) =
-        "World\n\
-        \    { currentPlaceName = " <> debug currentPlaceName <> "\n\
-        \    , places = " <> debug places <> "\n\
-        \    , commands = " <> "<???>" <> "\n\
-        \    , inventory = " <> "<???>" <> "\n\
-        \    }"
+  debug (World { currentPlaceName, places, commands, inventory }) =
+    "World\n\
+    \  { currentPlaceName = " <> debug currentPlaceName <> "\n\
+    \  , places = " <> debug places <> "\n\
+    \  , commands = " <> "<???>" <> "\n\
+    \  , inventory = " <> "<???>" <> "\n\
+    \  }"
 
 data Command = Command String Regex
 
 instance eqCommand :: Eq Command where
-    eq (Command a _) (Command b _) = eq a b
+  eq (Command a _) (Command b _) = eq a b
 
 instance ordCommand :: Ord Command where
-    compare (Command a _) (Command b _) = compare a b
+  compare (Command a _) (Command b _) = compare a b
 
 instance showCommand :: Show Command where
-    show (Command a _) = "command " <> a
+  show (Command a _) = "command " <> a
 
 type CommandHandler = List String -> Action Unit
 
@@ -127,37 +127,37 @@ newtype History = History (List HistoricalEntry)
 derive instance genericHistory :: Generic History
 
 instance eqHistory :: Eq History where
-    eq = gEq
+  eq = gEq
 
 instance ordHistory :: Ord History where
-    compare = gCompare
+  compare = gCompare
 
 instance monoidHistory :: Monoid History where
-    mempty = History Nil
+  mempty = History Nil
 
 instance semigroupHistory :: Semigroup History where
-    append (History a) (History b) = History (a <> b)
+  append (History a) (History b) = History (a <> b)
 
 instance showHistory :: Show History where
-    show = gShow
+  show = gShow
 
 data HistoricalEntry
-    = Message String
-    | Echo String
-    | Heading String
-    | Error String
-    | Debug String
+  = Message String
+  | Echo String
+  | Heading String
+  | Error String
+  | Debug String
 
 derive instance genericHistoricalEntry :: Generic HistoricalEntry
 
 instance eqHistoricalEntry :: Eq HistoricalEntry where
-    eq = gEq
+  eq = gEq
 
 instance ordHistoricalEntry:: Ord HistoricalEntry where
-    compare = gCompare
+  compare = gCompare
 
 instance showHistoricalEntry :: Show HistoricalEntry where
-    show = gShow
+  show = gShow
 
 -- TODO: wrap in newtype.
 type Places = StrMap Place

--- a/src/Skald/Internal.purs
+++ b/src/Skald/Internal.purs
@@ -33,7 +33,6 @@ import Data.Monoid (class Monoid)
 import Data.String.Regex (Regex)
 import Data.StrMap (StrMap)
 import Data.Tuple (Tuple)
-
 import Skald.Debug (class Debug, debug)
 import Skald.Direction (Direction)
 

--- a/src/Skald/Model.purs
+++ b/src/Skald/Model.purs
@@ -4,17 +4,17 @@
 -- http://opensource.org/licenses/MIT>. This file may not be copied, modified,
 -- or distributed except according to those terms.
 
-module Skald.Model (
-    Model,
-    empty,
-    history,
-    setHistory,
-    appendHistory,
-    world,
-    setWorld,
-    inputField,
-    setInputField
-    ) where
+module Skald.Model
+  ( Model
+  , empty
+  , history
+  , setHistory
+  , appendHistory
+  , world
+  , setWorld
+  , inputField
+  , setInputField
+  ) where
 
 import Prelude
 

--- a/src/Skald/Model.purs
+++ b/src/Skald/Model.purs
@@ -17,9 +17,7 @@ module Skald.Model
   ) where
 
 import Prelude
-
 import Data.Monoid (mempty)
-
 import Skald.Action as Action
 import Skald.History (History)
 import Skald.World (World)

--- a/src/Skald/Model.purs
+++ b/src/Skald/Model.purs
@@ -23,19 +23,19 @@ import Skald.History (History)
 import Skald.World (World)
 
 -- | Contains the entirety of a Skald application's state.
-data Model = Model {
-    history :: History,
-    world :: World,
-    inputField :: String
-    }
+data Model = Model
+  { history :: History
+  , world :: World
+  , inputField :: String
+  }
 
 -- | An empty model.
 empty :: Model
-empty = Model {
-    history: mempty,
-    world: Action.emptyWorld,
-    inputField: ""
-    }
+empty = Model
+  { history: mempty
+  , world: Action.emptyWorld
+  , inputField: ""
+  }
 
 -- | The given model's history.
 history :: Model -> History
@@ -48,7 +48,7 @@ setHistory newHistory (Model model) = Model (model { history = newHistory })
 -- | Append the given entries to the model's history.
 appendHistory :: History -> Model -> Model
 appendHistory entries (Model model) =
-    Model (model { history = model.history <> entries })
+  Model (model { history = model.history <> entries })
 
 -- | The world contained in the given model.
 world :: Model -> World
@@ -65,4 +65,4 @@ inputField (Model model) = model.inputField
 -- | Set the contents of the input field for the given model.
 setInputField :: String -> Model -> Model
 setInputField newInputField (Model model) =
-    Model (model { inputField = newInputField })
+  Model (model { inputField = newInputField })

--- a/src/Skald/Object.purs
+++ b/src/Skald/Object.purs
@@ -4,16 +4,16 @@
 -- http://opensource.org/licenses/MIT>. This file may not be copied, modified,
 -- or distributed except according to those terms.
 
-module Skald.Object (
-    module InternalExports,
-    object,
-    scenery,
-    name,
-    description,
-    fixedInPlace,
-    insteadOf,
-    command
-    ) where
+module Skald.Object
+  ( module InternalExports
+  , object
+  , scenery
+  , name
+  , description
+  , fixedInPlace
+  , insteadOf
+  , command
+  ) where
 
 import Prelude
 

--- a/src/Skald/Object.purs
+++ b/src/Skald/Object.purs
@@ -19,9 +19,8 @@ import Prelude
 
 import Data.Map as Map
 import Data.Maybe (Maybe)
-
 import Skald.Internal (Object) as InternalExports
-import Skald.Internal (Action, Command, Object (..))
+import Skald.Internal (Action, Command, Object(..))
 
 -- | Creates a new object with the given name and description.
 object :: String -> String -> Object

--- a/src/Skald/Object.purs
+++ b/src/Skald/Object.purs
@@ -16,7 +16,6 @@ module Skald.Object
   ) where
 
 import Prelude
-
 import Data.Map as Map
 import Data.Maybe (Maybe)
 import Skald.Internal (Object) as InternalExports
@@ -24,21 +23,21 @@ import Skald.Internal (Action, Command, Object(..))
 
 -- | Creates a new object with the given name and description.
 object :: String -> String -> Object
-object name' description' = Object {
-    name: name',
-    description: description',
-    fixedInPlace: false,
-    commands: Map.empty
-    }
+object name' description' = Object
+  { name: name'
+  , description: description'
+  , fixedInPlace: false
+  , commands: Map.empty
+  }
 
 -- | Creates a new scenery object with the given name and description.
 scenery :: String -> String -> Object
-scenery name' description' = Object {
-    name: name',
-    description: description',
-    fixedInPlace: true,
-    commands: Map.empty
-    }
+scenery name' description' = Object
+  { name: name'
+  , description: description'
+  , fixedInPlace: true
+  , commands: Map.empty
+  }
 
 -- | The name of the given object.
 name :: Object -> String
@@ -57,8 +56,8 @@ fixedInPlace (Object object') = object'.fixedInPlace
 -- TODO: add other combinators, i.e. before, after, etc.
 insteadOf :: Command -> Action Unit -> Object -> Object
 insteadOf command' action (Object object'@{ commands: commands' }) =
-    Object (object' { commands = Map.insert command' action commands' })
+  Object (object' { commands = Map.insert command' action commands' })
 
 command :: Command -> Object -> Maybe (Action Unit)
 command command' (Object { commands: commands' }) =
-    Map.lookup command' commands'
+  Map.lookup command' commands'

--- a/src/Skald/Place.purs
+++ b/src/Skald/Place.purs
@@ -50,13 +50,13 @@ import Skald.Object (Object)
 
 -- | Creates a new place with the given name.
 place :: String -> Place
-place name' = Place {
-    name: name',
-    describer: const "",
-    exits: Exits Map.empty,
-    objects: Objects StrMap.empty,
-    visited: false
-    }
+place name' = Place
+  { name: name'
+  , describer: const ""
+  , exits: Exits Map.empty
+  , objects: Objects StrMap.empty
+  , visited: false
+  }
 
 -- | An empty place.
 empty :: Place
@@ -103,7 +103,7 @@ objects (Place place') = place'.objects
 -- exists.
 object :: String -> Place -> Maybe Object
 object name' (Place { objects: Objects objects' }) =
-    StrMap.lookup name' objects'
+  StrMap.lookup name' objects'
 
 -- | Modify the given place's contained objects with the given function.
 updateObjects :: (Objects -> Objects) -> Place -> Place
@@ -112,16 +112,16 @@ updateObjects f (Place place') = Place (place' { objects = f place'.objects })
 -- | Remove an object from the given place.
 removeObject :: Object -> Place -> Place
 removeObject object' =
-    updateObjects
-        \(Objects x) -> Objects (StrMap.delete (Object.name object') x)
+  updateObjects
+    \(Objects x) -> Objects (StrMap.delete (Object.name object') x)
 
 -- | Add an object to the given place.
 addObject :: Object -> Place -> Place
 addObject object' =
-    updateObjects
-        \(Objects x) -> Objects (StrMap.insert (Object.name object') object' x)
+  updateObjects
+    \(Objects x) -> Objects (StrMap.insert (Object.name object') object' x)
 
 -- | The list of names of objects contained in the given place.
 objectNames :: Place -> List String
 objectNames (Place { objects: Objects objects' }) =
-    List.fromFoldable (StrMap.keys objects')
+  List.fromFoldable (StrMap.keys objects')

--- a/src/Skald/Place.purs
+++ b/src/Skald/Place.purs
@@ -38,15 +38,13 @@ module Skald.Place
   ) where
 
 import Prelude
-
 import Data.List as List
 import Data.List (List)
 import Data.Map as Map
 import Data.Maybe (Maybe)
 import Data.StrMap as StrMap
-
 import Skald.Direction (Direction)
-import Skald.Internal (Place (..), Exits (..), Objects (..))
+import Skald.Internal (Place(..), Exits(..), Objects(..))
 import Skald.Object as Object
 import Skald.Object (Object)
 

--- a/src/Skald/Place.purs
+++ b/src/Skald/Place.purs
@@ -6,36 +6,36 @@
 
 -- | Places are discrete areas of the world containing objects the player can
 -- directly interact with.
-module Skald.Place (
-    -- TODO: don't export innards.
-    module Skald.Internal,
+module Skald.Place
+  ( -- TODO: don't export innards.
+    module Skald.Internal
 
-    -- * Construction
-    place,
-    empty,
+  -- * Construction
+  , place
+  , empty
 
-    -- * Names and descriptions
-    name,
-    description,
+  -- * Names and descriptions
+  , name
+  , description
 
-    -- * Exits
-    exits,
-    exitName,
-    exitDirections,
+  -- * Exits
+  , exits
+  , exitName
+  , exitDirections
 
-    -- * Visited
-    visited,
-    unvisited,
-    setVisited,
+  -- * Visited
+  , visited
+  , unvisited
+  , setVisited
 
-    -- * Objects
-    objects,
-    object,
-    updateObjects,
-    removeObject,
-    addObject,
-    objectNames
-    ) where
+  -- * Objects
+  , objects
+  , object
+  , updateObjects
+  , removeObject
+  , addObject
+  , objectNames
+  ) where
 
 import Prelude
 

--- a/src/Skald/PlaceBuilder.purs
+++ b/src/Skald/PlaceBuilder.purs
@@ -14,17 +14,15 @@ module Skald.PlaceBuilder
   ) where
 
 import Prelude
-
 import Data.Foldable (foldr)
 import Data.Map as Map
 import Data.StrMap as StrMap
-import Data.Tuple (Tuple (..))
-
+import Data.Tuple (Tuple(..))
 import Skald.Direction (Direction)
 import Skald.Object as Object
 import Skald.Object (Object)
 import Skald.Place as Place
-import Skald.Place (Place (..))
+import Skald.Place (Place(..))
 
 {-
 

--- a/src/Skald/PlaceBuilder.purs
+++ b/src/Skald/PlaceBuilder.purs
@@ -4,14 +4,14 @@
 -- http://opensource.org/licenses/MIT>. This file may not be copied, modified,
 -- or distributed except according to those terms.
 
-module Skald.PlaceBuilder (
-    withDescription,
-    whenDescribing,
-    withExit,
-    withExits,
-    to,
-    containing
-    ) where
+module Skald.PlaceBuilder
+  ( withDescription
+  , whenDescribing
+  , withExit
+  , withExits
+  , to
+  , containing
+  ) where
 
 import Prelude
 

--- a/src/Skald/PlaceBuilder.purs
+++ b/src/Skald/PlaceBuilder.purs
@@ -24,40 +24,26 @@ import Skald.Object (Object)
 import Skald.Place as Place
 import Skald.Place (Place(..))
 
-{-
-
-data PlaceBuilder = PlaceBuilder {
-    name :: String,
-    describer :: Place -> String,
-    exits :: Exits,
-    objects :: Objects,
-    visited :: Boolean
-    }
-
--}
-
-
-
 withDescription :: String -> Place -> Place
 withDescription description' (Place place') =
-    Place (place' { describer = const description' })
+  Place (place' { describer = const description' })
 
 whenDescribing :: (Place -> String) -> Place -> Place
 whenDescribing describer' (Place place') =
-    Place (place' { describer = describer' })
+  Place (place' { describer = describer' })
 
 -- | `withExit direction exitName place`
 withExit :: Direction -> String -> Place -> Place
 withExit direction exitName' (Place place'@{ exits: Place.Exits exits' }) =
-    Place (place' { exits = Place.Exits (Map.insert direction exitName' exits') })
+  Place (place' { exits = Place.Exits (Map.insert direction exitName' exits') })
 
 withExits :: Array (Tuple Direction String) -> Place -> Place
 withExits exits'' (Place place'@{ exits: Place.Exits exits' }) =
-    Place (place' { exits = Place.Exits (update exits') })
-    where
-        update x =
-            foldr (\(Tuple direction exitName') ->
-                Map.insert direction exitName') x exits''
+  Place (place' { exits = Place.Exits (update exits') })
+  where
+    update x =
+      foldr (\(Tuple direction exitName') ->
+        Map.insert direction exitName') x exits''
 
 to :: forall a b. a -> b -> Tuple a b
 to = Tuple
@@ -65,9 +51,9 @@ to = Tuple
 -- | Adds the given objects to the given place.
 containing :: Array Object -> Place -> Place
 containing objects'' (Place place'@{ objects: Place.Objects objects' }) =
-    Place (place' { objects = Place.Objects (update objects') })
-    where
-        update x =
-            -- TODO: reuse addObject.
-            foldr (\object' -> StrMap.insert (Object.name object') object') x
-                objects''
+  Place (place' { objects = Place.Objects (update objects') })
+  where
+    update x =
+      -- TODO: reuse addObject.
+      foldr (\object' -> StrMap.insert (Object.name object') object') x
+        objects''

--- a/src/Skald/Tale.purs
+++ b/src/Skald/Tale.purs
@@ -30,21 +30,21 @@ import Skald.Place (Place)
 import Skald.World as World
 import Skald.World (World)
 
-data Tale = Tale {
-    title :: String,
-    author :: String,
-    initialWorld :: World,
-    preamble :: Tale -> String
-    }
+data Tale = Tale
+  { title :: String
+  , author :: String
+  , initialWorld :: World
+  , preamble :: Tale -> String
+  }
 
 -- | Creates an empty tale with the given title.
 tale :: String -> Tale
-tale title' = Tale {
-    title: title',
-    author: "",
-    initialWorld: Action.emptyWorld,
-    preamble: defaultPreamble
-    }
+tale title' = Tale
+  { title: title'
+  , author: ""
+  , initialWorld: Action.emptyWorld
+  , preamble: defaultPreamble
+  }
 
 -- | The title of the given tale.
 title :: Tale -> String
@@ -82,30 +82,30 @@ withPreamble preamble' (Tale tale') = Tale (tale' { preamble = preamble' })
 -- | Sets the place where the tale begins.
 thatBeginsIn :: Place -> Tale -> Tale
 thatBeginsIn place (Tale tale') =
-    withPlace place
-    $ Tale (tale' { initialWorld = World.setCurrentPlace place tale'.initialWorld })
+  withPlace place
+  $ Tale (tale' { initialWorld = World.setCurrentPlace place tale'.initialWorld })
 
 -- | Adds the given place to the tale.
 withPlace :: Place -> Tale -> Tale
 withPlace place (Tale tale') =
-    Tale (tale' { initialWorld = newWorld })
-    where
-        update = StrMap.insert (Place.name place) place
-        newWorld = World.updatePlaces update tale'.initialWorld
+  Tale (tale' { initialWorld = newWorld })
+  where
+    update = StrMap.insert (Place.name place) place
+    newWorld = World.updatePlaces update tale'.initialWorld
 
 -- | Adds the given places to the tale.
 withPlaces :: Array Place -> Tale -> Tale
 withPlaces places (Tale tale') =
-    Tale (tale' { initialWorld = newWorld })
-    where
-        update world =
-            foldl (\places' place -> StrMap.insert (Place.name place) place places') world places
-        newWorld = World.updatePlaces update tale'.initialWorld
+  Tale (tale' { initialWorld = newWorld })
+  where
+    update world =
+      foldl (\places' place -> StrMap.insert (Place.name place) place places') world places
+    newWorld = World.updatePlaces update tale'.initialWorld
 
 -- | `withCommand pattern handler tale`
 withCommand :: String -> Command.Handler -> Tale -> Tale
 withCommand pattern handler (Tale tale') =
-    Tale (tale' { initialWorld = newWorld })
-    where
-        update = Command.insert (command pattern) handler
-        newWorld = World.updateCommands update tale'.initialWorld
+  Tale (tale' { initialWorld = newWorld })
+  where
+    update = Command.insert (command pattern) handler
+    newWorld = World.updateCommands update tale'.initialWorld

--- a/src/Skald/Tale.purs
+++ b/src/Skald/Tale.purs
@@ -20,10 +20,8 @@ module Skald.Tale
   ) where
 
 import Prelude
-
 import Data.Foldable (foldl)
 import Data.StrMap as StrMap
-
 import Skald.Action as Action
 import Skald.Command as Command
 import Skald.Command (command)

--- a/src/Skald/Tale.purs
+++ b/src/Skald/Tale.purs
@@ -4,20 +4,20 @@
 -- http://opensource.org/licenses/MIT>. This file may not be copied, modified,
 -- or distributed except according to those terms.
 
-module Skald.Tale (
-    Tale(..),
-    tale,
-    title,
-    author,
-    initialWorld,
-    preamble,
-    by,
-    withPreamble,
-    thatBeginsIn,
-    withPlace,
-    withPlaces,
-    withCommand
-    ) where
+module Skald.Tale
+  ( Tale(..)
+  , tale
+  , title
+  , author
+  , initialWorld
+  , preamble
+  , by
+  , withPreamble
+  , thatBeginsIn
+  , withPlace
+  , withPlaces
+  , withCommand
+  ) where
 
 import Prelude
 

--- a/src/Skald/World.purs
+++ b/src/Skald/World.purs
@@ -42,15 +42,13 @@ module Skald.World
   ) where
 
 import Prelude
-
 import Data.List as List
-import Data.List (List (..))
-import Data.Maybe (Maybe (..))
+import Data.List (List(..))
+import Data.Maybe (Maybe(..))
 import Data.StrMap (StrMap)
 import Data.StrMap as StrMap
-
 import Skald.Internal (Inventory, Places, World) as InternalExports
-import Skald.Internal (CommandMap, Inventory (..), World (..))
+import Skald.Internal (CommandMap, Inventory(..), World(..))
 import Skald.Object as Object
 import Skald.Object (Object)
 import Skald.Place as Place

--- a/src/Skald/World.purs
+++ b/src/Skald/World.purs
@@ -4,42 +4,42 @@
 -- http://opensource.org/licenses/MIT>. This file may not be copied, modified,
 -- or distributed except according to those terms.
 
-module Skald.World (
-    module InternalExports,
+module Skald.World
+  ( module InternalExports
 
-    -- * Construction
-    empty,
+  -- * Construction
+  , empty
 
-    -- * Places
-    places,
-    setPlaces,
-    updatePlaces,
-    place,
+  -- * Places
+  , places
+  , setPlaces
+  , updatePlaces
+  , place
 
-    -- * Current place
-    currentPlace,
-    setCurrentPlace,
-    updateCurrentPlace,
+  -- * Current place
+  , currentPlace
+  , setCurrentPlace
+  , updateCurrentPlace
 
-    -- * Objects
-    removeObject,
-    addObject,
+  -- * Objects
+  , removeObject
+  , addObject
 
-    -- * Commands
-    commands,
-    setCommands,
-    updateCommands,
+  -- * Commands
+  , commands
+  , setCommands
+  , updateCommands
 
-    -- * Inventory
-    inventory,
-    item,
-    updateInventory,
-    -- TODO: re-export from Skald.
-    inventoryIsEmpty,
-    addToInventory,
-    removeFromInventory,
-    inventoryNames
-    ) where
+  -- * Inventory
+  , inventory
+  , item
+  , updateInventory
+  -- TODO: re-export from Skald.
+  , inventoryIsEmpty
+  , addToInventory
+  , removeFromInventory
+  , inventoryNames
+  ) where
 
 import Prelude
 

--- a/src/Skald/World.purs
+++ b/src/Skald/World.purs
@@ -56,12 +56,12 @@ import Skald.Place (Place)
 
 -- | An empty world.
 empty :: World
-empty = World {
-    currentPlaceName: "",
-    places: StrMap.empty,
-    commands: Nil,
-    inventory: Inventory StrMap.empty
-    }
+empty = World
+  { currentPlaceName: ""
+  , places: StrMap.empty
+  , commands: Nil
+  , inventory: Inventory StrMap.empty
+  }
 
 -- | The places contained in the given world.
 places :: World -> StrMap Place
@@ -77,8 +77,8 @@ updatePlaces f (World world) = World (world { places = f world.places })
 
 place :: String -> World -> Place
 place name world = case StrMap.lookup name (places world) of
-    Just place' -> place'
-    Nothing -> Place.empty
+  Just place' -> place'
+  Nothing -> Place.empty
 
 currentPlace :: World -> Place
 currentPlace (World world) = place world.currentPlaceName (World world)
@@ -86,11 +86,11 @@ currentPlace (World world) = place world.currentPlaceName (World world)
 -- | Sets the current place in the given world.
 setCurrentPlace :: Place -> World -> World
 setCurrentPlace place' (World world) =
-    World (world { places = places', currentPlaceName = Place.name place' })
-    where
-        -- TODO: is this really necessary?
-        places' =
-            StrMap.insert (Place.name place') place' (places (World world))
+  World (world { places = places', currentPlaceName = Place.name place' })
+  where
+    -- TODO: is this really necessary?
+    places' =
+      StrMap.insert (Place.name place') place' (places (World world))
 
 updateCurrentPlace :: (Place -> Place) -> World -> World
 updateCurrentPlace f world = setCurrentPlace (f (currentPlace world)) world
@@ -120,34 +120,34 @@ inventory (World world) = world.inventory
 -- given name, if it exists.
 item :: String -> World -> Maybe Object
 item name (World { inventory: Inventory inventory' }) =
-    StrMap.lookup name inventory'
+  StrMap.lookup name inventory'
 
 -- | Applies a function over the given world's player inventory.
 updateInventory :: (Inventory -> Inventory) -> World -> World
 updateInventory f (World world) =
-    World (world { inventory = f world.inventory })
+  World (world { inventory = f world.inventory })
 
 -- | Whether the given world's player inventory is empty.
 inventoryIsEmpty :: World -> Boolean
 inventoryIsEmpty (World { inventory: Inventory inventory' }) =
-    StrMap.isEmpty inventory'
+  StrMap.isEmpty inventory'
 
 -- | Adds an object to the given world's player inventory.
 addToInventory :: Object -> World -> World
 addToInventory object (World world@{ inventory: Inventory inventory' }) =
-    World (world { inventory = Inventory update })
-    where
-        update = StrMap.insert (Object.name object) object inventory'
+  World (world { inventory = Inventory update })
+  where
+    update = StrMap.insert (Object.name object) object inventory'
 
 -- | Removes an object from the given world's player inventory.
 removeFromInventory :: Object -> World -> World
 removeFromInventory object (World world@{ inventory: Inventory inventory' }) =
-    World (world { inventory = Inventory update })
-    where
-        update = StrMap.delete (Object.name object) inventory'
+  World (world { inventory = Inventory update })
+  where
+    update = StrMap.delete (Object.name object) inventory'
 
 -- | The list of names of objects contained in the given world's player
 -- inventory.
 inventoryNames :: World -> List String
 inventoryNames (World { inventory: Inventory inventory' }) =
-    List.fromFoldable (StrMap.keys inventory')
+  List.fromFoldable (StrMap.keys inventory')


### PR DESCRIPTION
This PR reformats the skald source code to match the rules outlined in https://github.com/ianbollinger/purescript-style-guide/blob/master/purescript-style.md
